### PR TITLE
Relax type checking

### DIFF
--- a/apollo-execution-processor/src/main/kotlin/com/apollographql/execution/processor/scalars.kt
+++ b/apollo-execution-processor/src/main/kotlin/com/apollographql/execution/processor/scalars.kt
@@ -27,6 +27,14 @@ internal fun KSAnnotated.getCoercing(logger: KSPLogger): SirCoercing? {
     return null
   }
 
+  val isCoercing = declaration.superTypes.any {
+    it.resolve().declaration.asClassName().asString() == "com.apollographql.execution.Coercing"
+  }
+  if (!isCoercing) {
+    logger.error("Coercing must implement 'com.apollographql.execution.Coercing'", declaration)
+    return null
+  }
+
   val instantiation = declaration.instantiation()
   if (instantiation == Instantiation.UNKNOWN) {
     logger.error("Coercing implementation must either be objects or have a no-arg constructor", declaration)

--- a/apollo-execution-runtime/api/apollo-execution-runtime.klib.api
+++ b/apollo-execution-runtime/api/apollo-execution-runtime.klib.api
@@ -238,9 +238,9 @@ open annotation class com.apollographql.execution.annotation/GraphQLQuery : kotl
     constructor <init>() // com.apollographql.execution.annotation/GraphQLQuery.<init>|<init>(){}[0]
 }
 open annotation class com.apollographql.execution.annotation/GraphQLScalar : kotlin/Annotation { // com.apollographql.execution.annotation/GraphQLScalar|null[0]
-    constructor <init>(kotlin.reflect/KClass<out com.apollographql.execution/Coercing<*>>) // com.apollographql.execution.annotation/GraphQLScalar.<init>|<init>(kotlin.reflect.KClass<out|com.apollographql.execution.Coercing<*>>){}[0]
+    constructor <init>(kotlin.reflect/KClass<*>) // com.apollographql.execution.annotation/GraphQLScalar.<init>|<init>(kotlin.reflect.KClass<*>){}[0]
     final val coercing // com.apollographql.execution.annotation/GraphQLScalar.coercing|{}coercing[0]
-        final fun <get-coercing>(): kotlin.reflect/KClass<out com.apollographql.execution/Coercing<*>> // com.apollographql.execution.annotation/GraphQLScalar.coercing.<get-coercing>|<get-coercing>(){}[0]
+        final fun <get-coercing>(): kotlin.reflect/KClass<*> // com.apollographql.execution.annotation/GraphQLScalar.coercing.<get-coercing>|<get-coercing>(){}[0]
 }
 open annotation class com.apollographql.execution.annotation/GraphQLSubscription : kotlin/Annotation { // com.apollographql.execution.annotation/GraphQLSubscription|null[0]
     constructor <init>() // com.apollographql.execution.annotation/GraphQLSubscription.<init>|<init>(){}[0]

--- a/apollo-execution-runtime/src/commonMain/kotlin/com/apollographql/execution/annotation/GraphQLScalar.kt
+++ b/apollo-execution-runtime/src/commonMain/kotlin/com/apollographql/execution/annotation/GraphQLScalar.kt
@@ -22,4 +22,4 @@ import kotlin.reflect.KClass
  * When using type aliases, you may use either the alias or the original type.
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS)
-annotation class GraphQLScalar(val coercing: KClass<out Coercing<*>>)
+annotation class GraphQLScalar(val coercing: KClass<*>)


### PR DESCRIPTION
The Kotlin compiler doesn't like to check recursive constructs.