### PR TITLE
Fix subprotocol

### DIFF
--- a/apollo-execution-ktor/src/commonMain/kotlin/com/apollographql/execution/ktor/main.kt
+++ b/apollo-execution-ktor/src/commonMain/kotlin/com/apollographql/execution/ktor/main.kt
@@ -107,7 +107,7 @@ fun Application.apolloSubscriptionModule(
   install(WebSockets)
 
   routing {
-    webSocket(path) {
+    webSocket(path, "graphql-ws") {
       coroutineScope {
         val handler = SubscriptionWebSocketHandler(
           executableSchema = executableSchema,


### PR DESCRIPTION
Also send the subprotocol in the response or else we get this error from the router

```
2025-07-22T18:48:42.101664Z ERROR subscribe{apollo.subgraph.name=foo,} execution{graphql.operation.type=subscription,} router{http.route=/,http.request.method=POST,http.request.method=POST,http.request.method=POST,http.route=/,url.path=/,client.name=,client.version=,}  subgraph call fetch error: HTTP fetch failed from 'foo': Websocket fetch failed from 'foo': cannot connect websocket to subgraph: WebSocket protocol error: SubProtocol error: Server sent no subprotocol
```

