### PR TITLE
Simplify the sandbox module even more

### DIFF
--- a/apollo-execution-ktor/src/commonMain/kotlin/com/apollographql/execution/ktor/main.kt
+++ b/apollo-execution-ktor/src/commonMain/kotlin/com/apollographql/execution/ktor/main.kt
@@ -137,23 +137,12 @@ fun Application.apolloSubscriptionModule(
 
 fun Application.apolloSandboxModule(
   title: String = "API sandbox",
-  graphqlPath: String = "/graphql",
   sandboxPath: String = "/",
+  endpoint: (RoutingCall) -> String = { it.url { path("/graphql") } },
 ) {
   routing {
     get(sandboxPath) {
-      val initialEndpoint = call.url {
-        /**
-         * Trying to guess if the client connected through HTTPS
-         */
-        val proto = call.request.header("x-forwarded-proto")
-        when (proto) {
-          "http" -> protocol = URLProtocol.HTTP
-          "https" -> protocol = URLProtocol.HTTPS
-        }
-        path(graphqlPath)
-      }
-      call.respondText(sandboxHtml(title, initialEndpoint), ContentType.parse("text/html"))
+      call.respondText(sandboxHtml(title, endpoint(call)), ContentType.parse("text/html"))
     }
   }
 }


### PR DESCRIPTION
It's almost impossible to guess the port and protocol used when the origin is not hit directly by the client. In those cases, make it configurable.